### PR TITLE
Fix memory corruption

### DIFF
--- a/r3d.h
+++ b/r3d.h
@@ -388,7 +388,7 @@ R3DDEF Model LoadModelAdvanced(const char *filename)
 
     // Load Materials
     model.materialCount = aiModel->mNumMaterials;
-    model.meshMaterial = (int *)R3D_CALLOC(model.meshCount, sizeof(int));
+    model.meshMaterial = (int *)R3D_CALLOC(aiModel->mNumMeshes, sizeof(int));
     model.materials = (Material *)R3D_CALLOC(model.materialCount, sizeof(Material));
 
     for (int i = 0; i < model.materialCount; i++)


### PR DESCRIPTION
Hi thanks for the extension for loading from assimp !

meshCount is 0 when allocating meshMaterial, which led to a scary malloc(0) and crash on UnloadModel.